### PR TITLE
fix http URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img src="http://img.shields.io/npm/v/@florantara/gatsby-theme-mercadolibre-store.svg?style=flat" alt="npm version">
+  <img src="https://img.shields.io/npm/v/@florantara/gatsby-theme-mercadolibre-store.svg?style=flat" alt="npm version">
   <img src="https://app.codeship.com/projects/d724b210-9925-0137-7a7c-5a4d2a496d42/status?branch=master" alt="TS checks and linting status">
 </p>
 


### PR DESCRIPTION
Hey there, I saw through some server logs for the Gatsby plugin library that this README has an HTTP URL in it. Since the file gets picked up as part of the plugin library on gatsbyjs.org, it ends up causing some insecure URL warnings when the site is built for HTTPS. I fixed it in this PR, let me know if you have any questions since this is probably pretty random! Thanks so much.